### PR TITLE
Add the ability to execute multiple queries at once

### DIFF
--- a/src/Lstr/Silex/Database/DatabaseService.php
+++ b/src/Lstr/Silex/Database/DatabaseService.php
@@ -47,11 +47,17 @@ class DatabaseService
 
     public function query($sql, array $params = array())
     {
-        $pdo   = $this->getPdo();
-        $query = $pdo->prepare($sql);
-        $query->execute($params);
+        return $this->queryWithOptions($sql, $params);
+    }
 
-        return $query;
+    public function queryMultiple($sql, array $params = array())
+    {
+        // turn on query emulation so multiple queries can be ran
+        $options = array(
+            PDO::ATTR_EMULATE_PREPARES => true,
+        );
+
+        return $this->queryWithOptions($sql, $params, $options);
     }
 
     public function getLastInsertId($sequence_table = null)
@@ -106,5 +112,14 @@ class DatabaseService
             ",
             $values
         );
+    }
+
+    private function queryWithOptions($sql, array $params = array(), array $options = array())
+    {
+        $pdo   = $this->getPdo();
+        $query = $pdo->prepare($sql, $options);
+        $query->execute($params);
+
+        return $query;
     }
 }


### PR DESCRIPTION
PDO/Postgres does not support natively preparing multiple queries in one `prepare` call. The `queryMultiple` will allow multiple queries to be ran together by turning on prepared statement emulation.
