### PR TITLE
Assert that all expected records existed

### DIFF
--- a/tests/src/Lstr/Silex/Database/DatabaseServiceTest.php
+++ b/tests/src/Lstr/Silex/Database/DatabaseServiceTest.php
@@ -319,8 +319,11 @@ SQL;
                 $expected_result = $expected_results[$row['id']];
                 $expected_result['id'] = $row['id'];
                 $this->assertEquals($expected_result, $row);
+                unset($expected_results[$row['id']]);
             }
         }
+
+        $this->assertEmpty($expected_results);
     }
 
     /**


### PR DESCRIPTION
Without the assertion, it was possible the table
contained no data and everything reported OK even
though rows were expected
